### PR TITLE
Update getText() to support FF

### DIFF
--- a/jymin.js
+++ b/jymin.js
@@ -720,7 +720,7 @@ var getText = function (
   // Ensure that we have an element, not just an ID.
   element = getElement(element);
   if (element) {
-    return element.textContent;
+    return element.textContent || element.innerText;
   }
 };
 


### PR DESCRIPTION
innerText doesn't work on FF, and textContent is the closest thing.
https://developer.mozilla.org/en-US/docs/Web/API/Node.textContent
